### PR TITLE
Week9/issue #60 인가코드 전송 방식으로 로그인 처리 방식 변경

### DIFF
--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,54 +1,39 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import Background from '@components/common/Background/index';
 import { HEADER_HEIGHT } from '@components/features/Layout/Header';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
-const KAKAO_CLIENT_ID = '5e729e0f7453b62edb99a52987e8819a';
-const KAKAO_REDIRECT_URI = 'http://localhost:3000/';
-const BACKEND_API_URL = 'http://52.79.221.195:8080/api/v1/auth/login';
-const KAKAO_TOKEN_URL = 'https://kauth.kakao.com/oauth/token';
+const KAKAO_CLIENT_ID = '26fa7f4117f85e9410f59d4fb651ef16';
+const KAKAO_REDIRECT_URI = 'http://localhost:3000';
+const BACKEND_API_URL = 'http://3.39.23.121:8080/api/v1/auth/login';
 const KAKAO_AUTH_URL = 'https://kauth.kakao.com/oauth/authorize';
 
 const LoginPage: React.FC = () => {
   const location = useLocation();
-  const navigate = useNavigate();
 
-  useEffect(() => {
+  React.useEffect(() => {
     const query = new URLSearchParams(location.search);
     const code = query.get('code');
 
     if (code) {
       axios
-        .post(KAKAO_TOKEN_URL, null, {
-          params: {
-            grant_type: 'authorization_code',
-            client_id: KAKAO_CLIENT_ID,
-            redirect_uri: KAKAO_REDIRECT_URI,
-            code,
-          },
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-        })
+        .post(
+          BACKEND_API_URL,
+          { code },
+          { headers: { 'Content-Type': 'application/json' } },
+        )
         .then((response) => {
           const accessToken = response.data.access_token;
           Cookies.set('access_token', accessToken);
-          return axios.post(
-            BACKEND_API_URL,
-            {},
-            {
-              headers: {
-                'Content-Type': 'application/json',
-                'access-token': Cookies.get('access_token'),
-              },
-            },
-          );
+        })
+        .catch((error) => {
+          console.error('로그인 실패:', error);
         });
     }
-  }, [location, navigate]);
+  }, [location]);
 
   const handleKakaoLogin = () => {
     const kakaoAuthUrl = `${KAKAO_AUTH_URL}?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;


### PR DESCRIPTION
## 📌 관련 이슈

#60 인가코드 전송 방식으로 로그인 처리 방식 변경

## ✨ PR 내용

- 카카오 로그인 API 요청 방식 변경
  - 기존: 프론트엔드에서 인가 코드를 통해 토큰 발급 후 백엔드에 로그인 요청
  - 변경: 프론트엔드에서 인가 코드를 백엔드로 전송하여 백엔드가 토큰 발급 및 로그인 처리